### PR TITLE
Update trytravis.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to Distrobe will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Output Travis URL and stop. #17 Reported by @miguelbalparda
+
 ## 1.0.4
 
 ### Fixed

--- a/trytravis.py
+++ b/trytravis.py
@@ -367,6 +367,12 @@ def _main(argv):
                 url = None
             _input_github_repo(url)
 
+        # No wait
+        elif arg in ['--no-wait', '-nw']:
+            url = _load_github_repo()
+            commit, committed = _submit_changes_to_github_repo(os.getcwd(), url)
+            build_id = _wait_for_travis_build(url, commit, committed)
+
         # Help string
         else:
             _main(['--help'])

--- a/trytravis.py
+++ b/trytravis.py
@@ -372,7 +372,7 @@ def _main(argv):
         # No wait
         elif arg in ['--no-wait', '-nw']:
             url = _load_github_repo()
-            commit, committed = _submit_changes_to_github_repo(os.getcwd(), 
+            commit, committed = _submit_changes_to_github_repo(os.getcwd(),
                                                                url)
             build_id = _wait_for_travis_build(url, commit, committed)
 

--- a/trytravis.py
+++ b/trytravis.py
@@ -71,6 +71,8 @@ _USAGE = ('usage: trytravis [command]?\n'
           'submitting an issue.\n'
           '  --repo, -r [repo]?    Tells the program you wish to setup '
           'your building repository.\n'
+          '  --no-wait, -nw            Don\'t wait for the builds to end.\n'
+
           '\n'
           'If you\'re still having troubles feel free to open an '
           'issue at our\nissue tracker: https://github.com/SethMichaelLarson'
@@ -370,7 +372,8 @@ def _main(argv):
         # No wait
         elif arg in ['--no-wait', '-nw']:
             url = _load_github_repo()
-            commit, committed = _submit_changes_to_github_repo(os.getcwd(), url)
+            commit, committed = _submit_changes_to_github_repo(os.getcwd(), 
+                                                               url)
             build_id = _wait_for_travis_build(url, commit, committed)
 
         # Help string


### PR DESCRIPTION
This PR should give trytravis the option to just submit the tests to Travis and don't wait until they are done.
Fixes #17 